### PR TITLE
Fix deprecation warning on build

### DIFF
--- a/plugin/src/main/java/com/owen1212055/biomevisuals/JsonAdapter.java
+++ b/plugin/src/main/java/com/owen1212055/biomevisuals/JsonAdapter.java
@@ -32,7 +32,7 @@ public class JsonAdapter {
         return GSON.toJsonTree(data).getAsJsonObject();
     }
 
-    public static JsonObject adapt(DimensionData data) {
+    public static JsonObject adapt(@SuppressWarnings("deprecation") DimensionData data) {
         return GSON.toJsonTree(data).getAsJsonObject();
     }
 }


### PR DESCRIPTION
When executing `./gradlew shadowJar` to generate the plugin JAR to distribute, a deprecation warning is shown, due to the usage of the publicly deprecated `DimensionData` API by the internal plugin code.

Conceptually, I think the whole dimension-related stuff can be cleaned up, because the plugin does not hook dimension-related registries. However, I've just silenced the warning to keep things simple in this PR. Please let me know if you'd like to see more thorough cleanups.