### PR TITLE
Add run-paper Gradle plugin files directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /api/build/
 /.idea/
 /build/
+/plugin/run/


### PR DESCRIPTION
The latest release of this plugin added a convenient Gradle task to test the plugin on a Paper server. This task generates transient files in the `plugin/run` directory. To avoid accidentally checking them in to source control, add them to `.gitignore`.