### PR TITLE
Associate the `biomevisuals.command` permission to /biomevisuals

### DIFF
--- a/plugin/src/main/java/com/owen1212055/biomevisuals/commands/BiomeVisualCommand.java
+++ b/plugin/src/main/java/com/owen1212055/biomevisuals/commands/BiomeVisualCommand.java
@@ -33,6 +33,7 @@ public class BiomeVisualCommand extends Command {
 
     public BiomeVisualCommand(Main main) {
         super("biomevisuals", "Main command for some utilities with the biome visual plugin.", USAGE_MESSAGE, List.of());
+        this.setPermission("biomevisuals.command");
         this.main = main;
     }
 


### PR DESCRIPTION
When a command does not have any permission linked to it, it can be used by any player on a server. However, it is undesirable to expose technical commands like /biomevisuals to anyone in a public server.

To better support such scenario, let's restrict the usage of the /biomevisuals command to those who have the `biomevisuals.command` permission. In the absence of any permission plugins, only server operators can use the command.